### PR TITLE
Fixes #6: Unable to find node on an unmounted component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,45 @@
 
 # recharts-to-png
 
+_For Recharts 1.X_
+
 Uses [html2canvas](https://github.com/niklasvh/html2canvas) to convert a [Recharts](https://github.com/recharts/recharts) chart to PNG.
 
 Inspired by these Stack Overflow questions and answers from [peter.bartos](https://stackoverflow.com/questions/45086005/recharts-component-to-png/56223127?noredirect=1#comment100914961_56223127) and [AlbertMunichMar](https://stackoverflow.com/questions/57206626/download-chart-as-png-format-in-react-without-overwriting-the-dom).
 
-### Demo
-
-See a [demo](https://csb-dyy8q.netlify.app/) using recharts-to-png alongside [FileSaver](https://www.npmjs.com/package/file-saver).
-
-### Install
+## Install
 
 ```
 npm install recharts-to-png
 ```
 
-### Usage
+## Hook
+
+The recommended way of using `recharts-to-png`. It is compatible with React 16.8+, does not rely on `findDOMNode`, and is required for React 17:
+
+```javascript
+import { useRechartToPng } from "recharts-to-png";
+
+const [png, ref] = useRechartToPng(options?);
+
+const handleDownload = React.useCallback(async () => {
+  FileSaver.saveAs(png, "myChart.png");
+}, [png]);
+
+return (
+  <LineChart ref={ref} ... />
+)
+```
+
+# Deprecated
+
+The original `getPngData` function this library offered does not work with React 17 (see [#6](https://github.com/brammitch/recharts-to-png/issues/6)). This section is still included for backwards compatibility, but will probably be removed at some point along with `getPngData`.
+
+#### Demo
+
+See a [demo](https://csb-dyy8q.netlify.app/) using recharts-to-png alongside [FileSaver](https://www.npmjs.com/package/file-saver).
+
+#### Usage
 
 ```javascript
 // chart: Element | React.Component | AreaChart | BarChart | PieChart | etc.
@@ -30,7 +54,7 @@ Allows all [html2canvas configuration options](https://html2canvas.hertzen.com/c
 await getPngData(chart, options);
 ```
 
-### Example
+#### Example
 
 ```javascript
 function App() {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import html2canvas from 'html2canvas';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   AreaChart,
@@ -9,7 +10,7 @@ import {
   RadarChart,
   RadialBarChart,
   ScatterChart,
-  Treemap,
+  Treemap
 } from 'recharts';
 
 export type RechartsChart =
@@ -24,8 +25,10 @@ export type RechartsChart =
   | Treemap;
 
 /**
+ * @deprecated Not compatible with React 17. Use the useRechartRef hook instead.
  * Returns a PNG URL string
  * @param instance - The Rechart component to generate the PNG for
+ * @param options - Html2Canvas formatting options
  */
 export async function getPngData(
   instance: Element | React.Component | RechartsChart,
@@ -38,4 +41,22 @@ export async function getPngData(
   );
 
   return pngData;
+}
+
+/**
+ * Returns a PNG URL string
+ * @param options - Html2Canvas formatting options
+ */
+export function useRechartToPng(options: Html2Canvas.Html2CanvasOptions = {}) {
+  const [png, setPng] = React.useState<any>(null);
+
+  const ref = React.useCallback(async (node: any) => {
+    if (node !== null && node?.container) {
+      const data = await html2canvas(node.container as HTMLElement, options).then((canvas) => canvas.toDataURL('image/png', 1.0));
+      setPng(data);
+    }
+
+  }, [options])
+
+  return [png, ref];
 }


### PR DESCRIPTION
Adds a hook `useRechartToPng` that works with React 17. Should fix #6 (and the same issue from #5).