### PR TITLE
feat(lib): :sparkles: enable copy to clipboard functionality to useCurrentPng hook

### DIFF
--- a/examples/next-app/app/page.tsx
+++ b/examples/next-app/app/page.tsx
@@ -35,9 +35,17 @@ const Home: NextPage = () => {
 
   // Composed chart setup
   const [composedData] = useState(getLgData(500));
-  const [getComposedPng, { ref: composedRef, isLoading }] = useCurrentPng();
+  const [getComposedPng, { ref: composedRef, isLoading, isCopyToClipboardLoading }] =
+    useCurrentPng();
   const handleComposedDownload = useCallback(async () => {
     const png = await getComposedPng();
+    if (png) {
+      FileSaver.saveAs(png, 'composed-chart.png');
+    }
+  }, [getComposedPng]);
+
+  const handleComposedCopyToClipboard = useCallback(async () => {
+    const png = await getComposedPng({ copyToClipboard: true });
     if (png) {
       FileSaver.saveAs(png, 'composed-chart.png');
     }
@@ -134,6 +142,23 @@ const Home: NextPage = () => {
               <i className="gg-software-download" />
               <span className="download-button-text">
                 <code>Download Composed Chart</code>
+              </span>
+            </span>
+          )}
+        </button>
+        <button disabled={isCopyToClipboardLoading} onClick={handleComposedCopyToClipboard}>
+          {isCopyToClipboardLoading ? (
+            <span className="download-button-content">
+              <i className="gg-spinner" />
+              <span className="download-button-text">
+                <code>Copying to Clipboard...</code>
+              </span>
+            </span>
+          ) : (
+            <span className="download-button-content">
+              <i className="gg-software-download" />
+              <span className="download-button-text">
+                <code>Copy Composed Chart to Clipboard</code>
               </span>
             </span>
           )}

--- a/examples/next-app/app/page.tsx
+++ b/examples/next-app/app/page.tsx
@@ -26,26 +26,24 @@ const Home: NextPage = () => {
   const [data01] = useState(getSmPieData());
   const [data02] = useState(getLgPieData());
   const [getPiePng, { ref: pieRef }] = useCurrentPng();
-  const handlePieDownload = useCallback(async () => {
-    const png = await getPiePng();
-    if (png) {
-      FileSaver.saveAs(png, 'pie-chart.png');
-    }
+  const handlePieCopyToClipboard = useCallback(async () => {
+    // Pass in optional callback for canvas.toBlob
+    await getPiePng((blob) => {
+      blob &&
+        navigator.clipboard.write([
+          new ClipboardItem({
+            // The key is determined dynamically based on the blob's type.
+            [blob.type]: blob,
+          }),
+        ]);
+    });
   }, [getPiePng]);
 
   // Composed chart setup
   const [composedData] = useState(getLgData(500));
-  const [getComposedPng, { ref: composedRef, isLoading, isCopyToClipboardLoading }] =
-    useCurrentPng();
+  const [getComposedPng, { ref: composedRef, isLoading }] = useCurrentPng();
   const handleComposedDownload = useCallback(async () => {
     const png = await getComposedPng();
-    if (png) {
-      FileSaver.saveAs(png, 'composed-chart.png');
-    }
-  }, [getComposedPng]);
-
-  const handleComposedCopyToClipboard = useCallback(async () => {
-    const png = await getComposedPng({ copyToClipboard: true });
     if (png) {
       FileSaver.saveAs(png, 'composed-chart.png');
     }
@@ -105,8 +103,8 @@ const Home: NextPage = () => {
           </PieChart>
         </ResponsiveContainer>
         <br />
-        <button onClick={handlePieDownload}>
-          <code>Download Pie Chart</code>
+        <button onClick={handlePieCopyToClipboard}>
+          <code>Copy Pie Chart to Clipboard</code>
         </button>
       </div>
       <div className="composed-chart">
@@ -142,23 +140,6 @@ const Home: NextPage = () => {
               <i className="gg-software-download" />
               <span className="download-button-text">
                 <code>Download Composed Chart</code>
-              </span>
-            </span>
-          )}
-        </button>
-        <button disabled={isCopyToClipboardLoading} onClick={handleComposedCopyToClipboard}>
-          {isCopyToClipboardLoading ? (
-            <span className="download-button-content">
-              <i className="gg-spinner" />
-              <span className="download-button-text">
-                <code>Copying to Clipboard...</code>
-              </span>
-            </span>
-          ) : (
-            <span className="download-button-content">
-              <i className="gg-software-download" />
-              <span className="download-button-text">
-                <code>Copy Composed Chart to Clipboard</code>
               </span>
             </span>
           )}

--- a/examples/next-pages/pages/index.tsx
+++ b/examples/next-pages/pages/index.tsx
@@ -25,55 +25,39 @@ const Home: NextPage = () => {
   // Area chart setup
   const [areaData] = useState(getLgData(100));
   const [getAreaPng, { ref: areaRef }] = useCurrentPng();
-  const handleAreaDownload = useCallback(
-    async (copyToClipboard?: boolean) => {
-      if (copyToClipboard) {
-        getAreaPng({ copyToClipboard });
-      } else {
-        const png = await getAreaPng();
-        if (png) {
-          FileSaver.saveAs(png, 'area-chart.png');
-        }
-      }
-    },
-    [getAreaPng]
-  );
+  const handleAreaDownload = useCallback(async () => {
+    const png = await getAreaPng();
+    if (png) {
+      FileSaver.saveAs(png, 'area-chart.png');
+    }
+  }, [getAreaPng]);
 
   // Pie chart setup
   const [data01] = useState(getSmPieData());
   const [data02] = useState(getLgPieData());
   const [getPiePng, { ref: pieRef }] = useCurrentPng();
-  const handlePieDownload = useCallback(
-    async (copyToClipboard?: boolean) => {
-      if (copyToClipboard) {
-        getPiePng({ copyToClipboard });
-      } else {
-        const png = await getPiePng();
-        if (png) {
-          FileSaver.saveAs(png, 'pie-chart.png');
-        }
-      }
-    },
-    [getPiePng]
-  );
+  const handlePieCopyToClipboard = useCallback(async () => {
+    // Pass in optional callback for canvas.toBlob
+    await getPiePng((blob) => {
+      blob &&
+        navigator.clipboard.write([
+          new ClipboardItem({
+            // The key is determined dynamically based on the blob's type.
+            [blob.type]: blob,
+          }),
+        ]);
+    });
+  }, [getPiePng]);
 
   // Composed chart setup
   const [composedData] = useState(getLgData(500));
-  const [getComposedPng, { ref: composedRef, isLoading, isCopyToClipboardLoading }] =
-    useCurrentPng();
-  const handleComposedDownload = useCallback(
-    async (copyToClipboard?: boolean) => {
-      if (copyToClipboard) {
-        getComposedPng({ copyToClipboard });
-      } else {
-        const png = await getComposedPng();
-        if (png) {
-          FileSaver.saveAs(png, 'composed-chart.png');
-        }
-      }
-    },
-    [getComposedPng]
-  );
+  const [getComposedPng, { ref: composedRef, isLoading }] = useCurrentPng();
+  const handleComposedDownload = useCallback(async () => {
+    const png = await getComposedPng();
+    if (png) {
+      FileSaver.saveAs(png, 'composed-chart.png');
+    }
+  }, [getComposedPng]);
 
   // Test div
   const [getDivPng, { ref: divRef }] = useGenerateImage<HTMLDivElement>();
@@ -135,11 +119,8 @@ const Home: NextPage = () => {
           </AreaChart>
         </ResponsiveContainer>
         <br />
-        <button onClick={() => handleAreaDownload()}>
+        <button onClick={handleAreaDownload}>
           <code>Download Area Chart</code>
-        </button>
-        <button onClick={() => handleAreaDownload(true)}>
-          <code>Copy Area Chart to Clipboard</code>
         </button>
       </div>
       <div className="pie-chart">
@@ -171,10 +152,7 @@ const Home: NextPage = () => {
           </PieChart>
         </ResponsiveContainer>
         <br />
-        <button onClick={() => handlePieDownload()}>
-          <code>Download Pie Chart</code>
-        </button>
-        <button onClick={() => handlePieDownload(true)}>
+        <button onClick={handlePieCopyToClipboard}>
           <code>Copy Pie Chart to Clipboard</code>
         </button>
       </div>
@@ -204,7 +182,7 @@ const Home: NextPage = () => {
           </ComposedChart>
         </ResponsiveContainer>
         <br />
-        <button disabled={isLoading} onClick={() => handleComposedDownload()}>
+        <button disabled={isLoading} onClick={handleComposedDownload}>
           {isLoading ? (
             <span className="download-button-content">
               <i className="gg-spinner" />
@@ -217,23 +195,6 @@ const Home: NextPage = () => {
               <i className="gg-software-download" />
               <span className="download-button-text">
                 <code>Download Composed Chart</code>
-              </span>
-            </span>
-          )}
-        </button>
-        <button disabled={isCopyToClipboardLoading} onClick={() => handleComposedDownload(true)}>
-          {isCopyToClipboardLoading ? (
-            <span className="download-button-content">
-              <i className="gg-spinner" />
-              <span className="download-button-text">
-                <code>Copying...</code>
-              </span>
-            </span>
-          ) : (
-            <span className="download-button-content">
-              <i className="gg-software-download" />
-              <span className="download-button-text">
-                <code>Copy Composed Chart To Clipboard</code>
               </span>
             </span>
           )}

--- a/examples/next-pages/pages/index.tsx
+++ b/examples/next-pages/pages/index.tsx
@@ -25,33 +25,55 @@ const Home: NextPage = () => {
   // Area chart setup
   const [areaData] = useState(getLgData(100));
   const [getAreaPng, { ref: areaRef }] = useCurrentPng();
-  const handleAreaDownload = useCallback(async () => {
-    const png = await getAreaPng();
-    if (png) {
-      FileSaver.saveAs(png, 'area-chart.png');
-    }
-  }, [getAreaPng]);
+  const handleAreaDownload = useCallback(
+    async (copyToClipboard?: boolean) => {
+      if (copyToClipboard) {
+        getAreaPng({ copyToClipboard });
+      } else {
+        const png = await getAreaPng();
+        if (png) {
+          FileSaver.saveAs(png, 'area-chart.png');
+        }
+      }
+    },
+    [getAreaPng]
+  );
 
   // Pie chart setup
   const [data01] = useState(getSmPieData());
   const [data02] = useState(getLgPieData());
   const [getPiePng, { ref: pieRef }] = useCurrentPng();
-  const handlePieDownload = useCallback(async () => {
-    const png = await getPiePng();
-    if (png) {
-      FileSaver.saveAs(png, 'pie-chart.png');
-    }
-  }, [getPiePng]);
+  const handlePieDownload = useCallback(
+    async (copyToClipboard?: boolean) => {
+      if (copyToClipboard) {
+        getPiePng({ copyToClipboard });
+      } else {
+        const png = await getPiePng();
+        if (png) {
+          FileSaver.saveAs(png, 'pie-chart.png');
+        }
+      }
+    },
+    [getPiePng]
+  );
 
   // Composed chart setup
   const [composedData] = useState(getLgData(500));
-  const [getComposedPng, { ref: composedRef, isLoading }] = useCurrentPng();
-  const handleComposedDownload = useCallback(async () => {
-    const png = await getComposedPng();
-    if (png) {
-      FileSaver.saveAs(png, 'composed-chart.png');
-    }
-  }, [getComposedPng]);
+  const [getComposedPng, { ref: composedRef, isLoading, isCopyToClipboardLoading }] =
+    useCurrentPng();
+  const handleComposedDownload = useCallback(
+    async (copyToClipboard?: boolean) => {
+      if (copyToClipboard) {
+        getComposedPng({ copyToClipboard });
+      } else {
+        const png = await getComposedPng();
+        if (png) {
+          FileSaver.saveAs(png, 'composed-chart.png');
+        }
+      }
+    },
+    [getComposedPng]
+  );
 
   // Test div
   const [getDivPng, { ref: divRef }] = useGenerateImage<HTMLDivElement>();
@@ -113,8 +135,11 @@ const Home: NextPage = () => {
           </AreaChart>
         </ResponsiveContainer>
         <br />
-        <button onClick={handleAreaDownload}>
+        <button onClick={() => handleAreaDownload()}>
           <code>Download Area Chart</code>
+        </button>
+        <button onClick={() => handleAreaDownload(true)}>
+          <code>Copy Area Chart to Clipboard</code>
         </button>
       </div>
       <div className="pie-chart">
@@ -146,8 +171,11 @@ const Home: NextPage = () => {
           </PieChart>
         </ResponsiveContainer>
         <br />
-        <button onClick={handlePieDownload}>
+        <button onClick={() => handlePieDownload()}>
           <code>Download Pie Chart</code>
+        </button>
+        <button onClick={() => handlePieDownload(true)}>
+          <code>Copy Pie Chart to Clipboard</code>
         </button>
       </div>
       <div className="class-composed-chart">
@@ -176,7 +204,7 @@ const Home: NextPage = () => {
           </ComposedChart>
         </ResponsiveContainer>
         <br />
-        <button disabled={isLoading} onClick={handleComposedDownload}>
+        <button disabled={isLoading} onClick={() => handleComposedDownload()}>
           {isLoading ? (
             <span className="download-button-content">
               <i className="gg-spinner" />
@@ -189,6 +217,23 @@ const Home: NextPage = () => {
               <i className="gg-software-download" />
               <span className="download-button-text">
                 <code>Download Composed Chart</code>
+              </span>
+            </span>
+          )}
+        </button>
+        <button disabled={isCopyToClipboardLoading} onClick={() => handleComposedDownload(true)}>
+          {isCopyToClipboardLoading ? (
+            <span className="download-button-content">
+              <i className="gg-spinner" />
+              <span className="download-button-text">
+                <code>Copying...</code>
+              </span>
+            </span>
+          ) : (
+            <span className="download-button-content">
+              <i className="gg-software-download" />
+              <span className="download-button-text">
+                <code>Copy Composed Chart To Clipboard</code>
               </span>
             </span>
           )}

--- a/lib/src/index.tsx
+++ b/lib/src/index.tsx
@@ -3,7 +3,7 @@ import html2canvas, { Options as HTML2CanvasOptions } from 'html2canvas';
 import { Component, createRef, useCallback, useRef, useState } from 'react';
 
 export type UseGenerateImage<T extends HTMLElement = HTMLDivElement> = [
-  () => Promise<string | undefined>,
+  (callback?: BlobCallback) => Promise<string | undefined>,
   {
     isLoading: boolean;
     ref: React.MutableRefObject<T | null>;
@@ -30,19 +30,25 @@ export function useGenerateImage<T extends HTMLElement = HTMLDivElement>(
   const ref = useRef<T>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const generateImage = useCallback(async () => {
-    if (ref !== null && ref?.current) {
-      setIsLoading(true);
+  const generateImage = useCallback(
+    async (callback?: BlobCallback) => {
+      if (ref !== null && ref?.current) {
+        setIsLoading(true);
 
-      return await html2canvas(ref.current as HTMLElement, {
-        logging: false,
-        ...args?.options,
-      }).then((canvas) => {
-        setIsLoading(false);
-        return canvas.toDataURL(args?.type, args?.quality);
-      });
-    }
-  }, [args]);
+        return await html2canvas(ref.current as HTMLElement, {
+          logging: false,
+          ...args?.options,
+        }).then((canvas) => {
+          if (callback) {
+            canvas.toBlob(callback, args?.type, args?.quality);
+          }
+          setIsLoading(false);
+          return canvas.toDataURL(args?.type, args?.quality);
+        });
+      }
+    },
+    [args]
+  );
 
   return [
     generateImage,
@@ -54,10 +60,9 @@ export function useGenerateImage<T extends HTMLElement = HTMLDivElement>(
 }
 
 export type UseCurrentPng = [
-  (c?: { copyToClipboard?: boolean }) => Promise<void | string | undefined>,
+  (callback?: BlobCallback) => Promise<string | undefined>,
   {
     isLoading: boolean;
-    isCopyToClipboardLoading: boolean;
     ref: React.MutableRefObject<any>;
   },
 ];
@@ -68,35 +73,19 @@ export type UseCurrentPng = [
 export function useCurrentPng(options?: Partial<HTML2CanvasOptions>): UseCurrentPng {
   const ref = useRef<any>();
   const [isLoading, setIsLoading] = useState(false);
-  const [isCopyToClipboardLoading, setIsCopyToClipboardLoading] = useState(false);
 
   const getPng = useCallback(
-    async (pngOptions?: { copyToClipboard?: boolean }) => {
+    async (callback?: BlobCallback) => {
       if (ref !== null && ref?.current?.container) {
-        !pngOptions?.copyToClipboard ? setIsLoading(true) : setIsCopyToClipboardLoading(true);
+        setIsLoading(true);
 
         return await html2canvas(ref.current.container as HTMLElement, {
           logging: false,
           ...options,
         }).then((canvas) => {
-          if (pngOptions?.copyToClipboard)
-            return canvas.toBlob(
-              (blob) => {
-                if (blob) {
-                  navigator.clipboard.write([
-                    new ClipboardItem(
-                      Object.defineProperty({}, 'image/png', {
-                        value: blob,
-                        enumerable: true,
-                      })
-                    ),
-                  ]);
-                  setIsCopyToClipboardLoading(false);
-                }
-              },
-              'image/png',
-              1.0
-            );
+          if (callback) {
+            canvas.toBlob(callback, 'image/png', 1.0);
+          }
           setIsLoading(false);
           return canvas.toDataURL('image/png', 1.0);
         });
@@ -110,7 +99,6 @@ export function useCurrentPng(options?: Partial<HTML2CanvasOptions>): UseCurrent
     {
       ref,
       isLoading,
-      isCopyToClipboardLoading,
     },
   ];
 }


### PR DESCRIPTION
Added optional `copyToClipboard` parameter to the `useCurrentPng` returned method which copies the element image to clipboard instead of saving the image to a file.
Added a `isCopyToClipboardLoading` status boolean to the returned tuple